### PR TITLE
Add ciq-grub2 virtual Provides (ciq7)

### DIFF
--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -230,6 +230,8 @@ Requires:	%{name}-tools = %{evr}					\
 # Add ciq-shim requirement, ONLY on ciq secureboot supported arches \
 %ifarch x86_64  \
 Requires: ciq-shim >= 15.8          \
+Provides:	ciq-grub2 = %{evr}					\
+Provides:	ciq-grub2-%{1} = %{evr}				\
 %endif   \
 %{-p:Provides:	%{name}-efi = %{evr}}					\
 %{-p:Obsoletes:	%{name}-efi <= %{flagday}}				\


### PR DESCRIPTION
Adds `ciq-grub2` and `ciq-grub2-%{1}` (→ `ciq-grub2-efi-x64`/`-aa64`/`-ia32`) Provides to the EFI variant package in `grub.macros`.

The CIQ shim 16.1 carries `Requires: ciq-grub2-efi-<arch>`, so it boots **only** this CIQ grub2 — never upstream RESF grub2, which lacks the `grub.ciq_*` SBAT entry and is not signed by the key the shim trusts. Reverse edge of the existing `Requires: ciq-shim` in `define_efi_variant`, so shim and grub2 install/upgrade as a unit.

Verified: `grub` SBAT generation `5` matches the shim `.sbatlevel` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)