### PR TITLE
Add ciq-grub2 virtual Provides (ciq8)

### DIFF
--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -289,6 +289,8 @@ Provides:	%{name}-efi = %{evr}					\
 # Add ciq-shim requirement, ONLY on ciq secureboot supported arches    \
 %ifarch x86_64 aarch64 \
 Requires: ciq-shim >= 15.8          \
+Provides:	ciq-grub2 = %{evr}					\
+Provides:	ciq-grub2-%{1} = %{evr}				\
 %endif   \
 %{?legacy_provides:Provides:	%{name} = %{evr}}			\
 %{-o:Obsoletes:	%{name}-efi < %{evr}}					\

--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -222,7 +222,11 @@
 
 %ifarch x86_64
 %global with_efi_common 1
-%global with_legacy_modules 0
+# Build grub2-pc-modules on x86_64 (upstream behavior). Without it, grub2-pc
+# requires a sibling that is never built, so it is uninstallable and cannot be
+# upgraded in lockstep with the rest of the stack (dnf "protected package"
+# removal error on any box that already has the stock grub2-pc).
+%global with_legacy_modules 1
 %global with_legacy_common 0
 %else
 %global with_efi_common 0

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -545,6 +545,9 @@ fi
 %changelog
 * Fri Jun 26 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.02-167.ciq.0.1.4
 - Epoch 1 -> 5 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 5 + kernel Requires ciq-shim).
+- Enable with_legacy_modules on x86_64 so grub2-pc-modules is built; without it
+  grub2-pc (which Requires grub2-pc-modules) is uninstallable and dnf upgrade
+  fails with "removing protected packages: grub2-pc" on stock-grub2-pc boxes.
 
 * Thu Apr 03 2026 Linux Engineering <le-team@ciq.com> - 2.02-167.3
 - Bump SBAT level grub,3 -> grub,5 to reflect CVE patches already present

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -5,9 +5,9 @@
 %global _configure_gnuconfig_hack 0
 
 Name:                 grub2
-Epoch:                1
+Epoch:                5
 Version:              2.02
-Release:              167%{?dist}.ciq.0.1.3
+Release:              167%{?dist}.ciq.0.1.4
 Summary:              Bootloader with support for Linux, Multiboot and more
 Group:                System Environment/Base
 License:              GPLv3+
@@ -543,6 +543,9 @@ fi
 %endif
 
 %changelog
+* Fri Jun 26 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.02-167.ciq.0.1.4
+- Epoch 1 -> 5 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 5 + kernel Requires ciq-shim).
+
 * Thu Apr 03 2026 Linux Engineering <le-team@ciq.com> - 2.02-167.3
 - Bump SBAT level grub,3 -> grub,5 to reflect CVE patches already present
 - Port patches 0678-0683 from grub2-rl8 (Rocky Linux 8):


### PR DESCRIPTION
Adds \`ciq-grub2\` and \`ciq-grub2-%{1}\` (→ \`ciq-grub2-efi-x64\`/\`-aa64\`/\`-ia32\`) Provides to the EFI variant package in \`grub.macros\`.

The CIQ shim 16.1 carries \`Requires: ciq-grub2-efi-<arch>\`, so it boots **only** this CIQ grub2 — never upstream RESF grub2, which lacks the \`grub.ciq_*\` SBAT entry and is not signed by the key the shim trusts. Reverse edge of the existing \`Requires: ciq-shim\` in \`define_efi_variant\`, so shim and grub2 install/upgrade as a unit.

Verified: \`grub\` SBAT generation \`5\` matches the shim \`.sbatlevel\` floor.

## Additional changes in this PR

### Epoch 1 → 5 (`SPECS/grub2.spec`)

The Epoch is bumped from 1 to 5 so that CIQ grub2 EVR outranks Rocky Linux's stock grub2 on a plain \`dnf upgrade\` — without this, a user running \`dnf upgrade\` on a CIQ system would pull in the upstream RESF grub2 instead of the CIQ build. Epoch 5 matches the shim and kernel Epoch strategy (both also at 5) so the entire secure-boot stack upgrades together.

**Upgrade path:** any box with Epoch 1 CIQ grub2 or Rocky grub2 (also Epoch 1) will upgrade to Epoch 5 CIQ grub2 on next \`dnf upgrade\`. Downgrade back to Epoch 1 requires \`--allow-erasing\`.

### Enable \`with_legacy_modules\` on x86\_64 (`SOURCES/grub.macros`)

The EL8 build had \`with_legacy_modules 0\` on x86\_64, which meant \`grub2-pc-modules\` was never built. Since \`grub2-pc\` carries \`Requires: grub2-pc-modules\`, it was uninstallable and \`dnf upgrade\` on any box with the stock \`grub2-pc\` installed would fail with:

> removing the following protected packages: grub2-pc

Setting \`with_legacy_modules 1\` restores upstream behavior and makes \`grub2-pc\` installable/upgradeable alongside the EFI packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)