### PR TITLE
el9 grub2 (ciq9): ciq-grub2 provides + grub2-pc-modules + Epoch 3

### DIFF
--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -216,7 +216,11 @@
 
 %ifarch x86_64
 %global with_efi_common 1
-%global with_legacy_modules 0
+# Build grub2-pc-modules on x86_64 (upstream behavior). Without it, grub2-pc
+# requires a sibling that is never built, so it is uninstallable and cannot be
+# upgraded in lockstep with the rest of the stack (dnf "protected package"
+# removal error on any box that already has the stock grub2-pc).
+%global with_legacy_modules 1
 %global with_legacy_common 0
 %else
 %global with_efi_common 0

--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -274,6 +274,8 @@ Requires:	%{name}-common = %{evr}					\
 Requires:	%{name}-tools-minimal >= %{evr}				\
 Requires:	%{name}-tools = %{evr}					\
 Provides:	%{name}-efi = %{evr}					\
+Provides:	ciq-grub2 = %{evr}					\
+Provides:	ciq-grub2-%{1} = %{evr}				\
 Requires:	ciq-shim >= 15.8						\
 %{?legacy_provides:Provides:	%{name} = %{evr}}			\
 %{-o:Obsoletes:	%{name}-efi < %{evr}}					\

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -14,9 +14,9 @@
 %global gnulibversion 9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 Name:                 grub2
-Epoch:                1
+Epoch:                3
 Version:              2.06
-Release:              114%{?dist}.ciq.0.1
+Release:              114%{?dist}.ciq.0.2
 Summary:              Bootloader with support for Linux, Multiboot and more
 License:              GPLv3+
 URL:                  http://www.gnu.org/software/grub/
@@ -573,6 +573,12 @@ fi
 %endif
 
 %changelog
+* Wed Jun 24 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.06-114.ciq.0.2
+- Enable with_legacy_modules on x86_64 so grub2-pc-modules is built and packaged.
+  Fixes grub2-pc being uninstallable/un-upgradeable (it requires grub2-pc-modules,
+  which was excluded on x86_64), which caused "removing the following protected
+  packages: grub2-pc" on any box with the stock grub2-pc installed.
+
 * Thu Feb 12 2026 Linux Engineering <le-team@ciq.com> - 2.06-114
 - Porting Rocky 9 secureboot grub2 to CIQ build and sign
 

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -574,6 +574,7 @@ fi
 
 %changelog
 * Wed Jun 24 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.06-114.ciq.0.2
+- Epoch 1 -> 3 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 3 + kernel Requires ciq-shim).
 - Enable with_legacy_modules on x86_64 so grub2-pc-modules is built and packaged.
   Fixes grub2-pc being uninstallable/un-upgradeable (it requires grub2-pc-modules,
   which was excluded on x86_64), which caused "removing the following protected


### PR DESCRIPTION
el9 CIQ grub2 deltas targeting `ciq9`:

1. **ciq-grub2 virtual Provides** — so the shim can `Requires: ciq-grub2-efi-<arch>` (and only CIQ grub2 satisfies it).
2. **grub2-pc-modules fix** — `with_legacy_modules 1` on x86_64 so `grub2-pc-modules` is built; fixes the `removing protected packages: grub2-pc` install failure. Release `.ciq.0.2`.
3. **Epoch: 1 → 3** — so CIQ grub2 outranks Rocky's on a plain `dnf upgrade` (Rocky el9 grub2 is epoch 1; CIQ `3:2.06-114` wins). Pairs with the shim's `Epoch: 3` + the kernel's `Requires: ciq-shim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)