### PR TITLE
el9 grub2 (ciq9): Epoch 3 → 5 (catch up to deployed/tested build)

### DIFF
--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -216,7 +216,11 @@
 
 %ifarch x86_64
 %global with_efi_common 1
-%global with_legacy_modules 0
+# Build grub2-pc-modules on x86_64 (upstream behavior). Without it, grub2-pc
+# requires a sibling that is never built, so it is uninstallable and cannot be
+# upgraded in lockstep with the rest of the stack (dnf "protected package"
+# removal error on any box that already has the stock grub2-pc).
+%global with_legacy_modules 1
 %global with_legacy_common 0
 %else
 %global with_efi_common 0

--- a/SOURCES/grub.macros
+++ b/SOURCES/grub.macros
@@ -274,6 +274,8 @@ Requires:	%{name}-common = %{evr}					\
 Requires:	%{name}-tools-minimal >= %{evr}				\
 Requires:	%{name}-tools = %{evr}					\
 Provides:	%{name}-efi = %{evr}					\
+Provides:	ciq-grub2 = %{evr}					\
+Provides:	ciq-grub2-%{1} = %{evr}				\
 Requires:	ciq-shim >= 15.8						\
 %{?legacy_provides:Provides:	%{name} = %{evr}}			\
 %{-o:Obsoletes:	%{name}-efi < %{evr}}					\

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -14,9 +14,9 @@
 %global gnulibversion 9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 Name:                 grub2
-Epoch:                1
+Epoch:                3
 Version:              2.06
-Release:              114%{?dist}.ciq.0.1
+Release:              114%{?dist}.ciq.0.2
 Summary:              Bootloader with support for Linux, Multiboot and more
 License:              GPLv3+
 URL:                  http://www.gnu.org/software/grub/
@@ -573,6 +573,12 @@ fi
 %endif
 
 %changelog
+* Wed Jun 24 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.06-114.ciq.0.2
+- Enable with_legacy_modules on x86_64 so grub2-pc-modules is built and packaged.
+  Fixes grub2-pc being uninstallable/un-upgradeable (it requires grub2-pc-modules,
+  which was excluded on x86_64), which caused "removing the following protected
+  packages: grub2-pc" on any box with the stock grub2-pc installed.
+
 * Thu Feb 12 2026 Linux Engineering <le-team@ciq.com> - 2.06-114
 - Porting Rocky 9 secureboot grub2 to CIQ build and sign
 

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -574,6 +574,7 @@ fi
 
 %changelog
 * Wed Jun 24 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.06-114.ciq.0.2
+- Epoch 1 -> 3 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 3 + kernel Requires ciq-shim).
 - Enable with_legacy_modules on x86_64 so grub2-pc-modules is built and packaged.
   Fixes grub2-pc being uninstallable/un-upgradeable (it requires grub2-pc-modules,
   which was excluded on x86_64), which caused "removing the following protected

--- a/SPECS/grub2.spec
+++ b/SPECS/grub2.spec
@@ -14,7 +14,7 @@
 %global gnulibversion 9f48fb992a3d7e96610c4ce8be969cff2d61a01b
 
 Name:                 grub2
-Epoch:                3
+Epoch:                5
 Version:              2.06
 Release:              114%{?dist}.ciq.0.2
 Summary:              Bootloader with support for Linux, Multiboot and more
@@ -574,7 +574,7 @@ fi
 
 %changelog
 * Wed Jun 24 2026 Jason Rodriguez <jrodriguez@ciq.com> - 2.06-114.ciq.0.2
-- Epoch 1 -> 3 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 3 + kernel Requires ciq-shim).
+- Epoch 1 -> 5 so CIQ grub2 outranks Rocky's on a plain dnf upgrade (pairs with shim Epoch 5 + kernel Requires ciq-shim).
 - Enable with_legacy_modules on x86_64 so grub2-pc-modules is built and packaged.
   Fixes grub2-pc being uninstallable/un-upgradeable (it requires grub2-pc-modules,
   which was excluded on x86_64), which caused "removing the following protected


### PR DESCRIPTION
Follow-up to #6 (which merged at Epoch 3). Release leadership set the shim/grub2 Epoch to **5**; this lands that bump on `ciq9` so the integration branch matches what is signed, deployed, and QA-tested on the repo server (`5:2.06-114.el9_ciq.ciq.0.2`).

- Single commit: `Epoch 1 → 5`.
- Multiarch (x86_64 + aarch64) — no arch-specific change; `grub2-efi-aa64` builds from the same spec.
- Epoch 5 lets a plain `dnf upgrade` pull CIQ grub2 over stock Rocky without priority/distro-sync (validated on EL9 DUTs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)